### PR TITLE
Fix pagination, when additional query params are involved

### DIFF
--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -25,6 +25,7 @@ const Pagination: FunctionComponent<Props> = ({ currentPage, pages }) => {
               router.push({
                 pathname: router.pathname,
                 query: {
+                  ...router.query,
                   page: p.toString(),
                 },
               })


### PR DESCRIPTION
Closes https://github.com/flathub/frontend/issues/1

Can be tested on pages such as http://localhost:3000/apps/category/Game?page=1
and using the pagination. This errored before.