### PR TITLE
Change category name to networking

### DIFF
--- a/src/components/application/Collection.tsx
+++ b/src/components/application/Collection.tsx
@@ -17,7 +17,7 @@ interface Props {
 const ApplicationCollection: FunctionComponent<Props> = ({
   applications,
   title,
-  perPage = 32,
+  perPage = 30,
 }) => {
   const router = useRouter()
   const page = parseInt((router.query.page ?? '1') as string)

--- a/src/types/Category.ts
+++ b/src/types/Category.ts
@@ -22,7 +22,7 @@ export function categoryToName(category: Category): string {
     case Category.Graphics:
       return 'Graphics & Photography'
     case Category.Network:
-      return 'Social Networking'
+      return 'Networking'
     case Category.Office:
       return 'Productivity'
     case Category.Utility:


### PR DESCRIPTION
As this category includes things like wireshark,
the name Social Networking seemed misleading.