### PR TITLE
Add frontend login flow

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider } from 'next-themes'
 import type { AppProps } from 'next/app'
 
 import 'react-responsive-carousel/lib/styles/carousel.min.css' // Requires a loader
+import { UserInfoProvider } from '../src/context/user-info'
 import { IMAGE_BASE_URL } from '../src/env'
 
 import '../styles/main.scss'
@@ -38,7 +39,9 @@ const App = ({ Component, pageProps }: AppProps) => {
             ],
           }}
         />
-        <Component {...pageProps} />
+        <UserInfoProvider>
+          <Component {...pageProps} />
+        </UserInfoProvider>
       </ThemeProvider>
     </MatomoProvider>
   )

--- a/pages/apps/collection/developer/[developer].tsx
+++ b/pages/apps/collection/developer/[developer].tsx
@@ -1,9 +1,10 @@
 import { GetStaticPaths, GetStaticProps } from 'next'
-
-import { fetchDeveloperApps, fetchDevelopers } from '../../../../src/fetchers'
-import ApplicationCollection from '../../../../src/components/application/Collection'
-import { Appstream } from '../../../../src/types/Appstream'
 import { NextSeo } from 'next-seo'
+import ApplicationCollection from '../../../../src/components/application/Collection'
+import Main from '../../../../src/components/layout/Main'
+import { fetchDeveloperApps, fetchDevelopers } from '../../../../src/fetchers'
+import { Appstream } from '../../../../src/types/Appstream'
+
 
 export default function Developer({
     developerApps,
@@ -13,13 +14,13 @@ export default function Developer({
     developer: string
 }) {
     return (
-        <>
+        <Main>
             <NextSeo title={`Applications by ${developer}`} />
             <ApplicationCollection
                 title={`Applications by ${developer}`}
                 applications={developerApps}
             />
-        </>
+        </Main>
     )
 }
 

--- a/pages/apps/collection/editors-choice-apps.tsx
+++ b/pages/apps/collection/editors-choice-apps.tsx
@@ -1,20 +1,21 @@
 import { GetStaticProps } from 'next'
-
-import ApplicationCollection from '../../../src/components/application/Collection'
-import fetchCollection from '../../../src/fetchers'
-import { Collections } from '../../../src/types/Collection'
-import { Appstream } from '../../../src/types/Appstream'
 import { NextSeo } from 'next-seo'
+import ApplicationCollection from '../../../src/components/application/Collection'
+import Main from '../../../src/components/layout/Main'
+import fetchCollection from '../../../src/fetchers'
+import { Appstream } from '../../../src/types/Appstream'
+import { Collections } from '../../../src/types/Collection'
+
 
 export default function EditorChoiceApps({ applications }) {
   return (
-    <>
+    <Main>
       <NextSeo title="Editor's Choice Apps" />
       <ApplicationCollection
         title="Editor's Choice Apps"
         applications={applications}
       />
-    </>
+    </Main>
   )
 }
 

--- a/pages/apps/collection/editors-choice-games.tsx
+++ b/pages/apps/collection/editors-choice-games.tsx
@@ -1,20 +1,21 @@
 import { GetStaticProps } from 'next'
-
-import ApplicationCollection from '../../../src/components/application/Collection'
-import fetchCollection from '../../../src/fetchers'
-import { Collections } from '../../../src/types/Collection'
-import { Appstream } from '../../../src/types/Appstream'
 import { NextSeo } from 'next-seo'
+import ApplicationCollection from '../../../src/components/application/Collection'
+import Main from '../../../src/components/layout/Main'
+import fetchCollection from '../../../src/fetchers'
+import { Appstream } from '../../../src/types/Appstream'
+import { Collections } from '../../../src/types/Collection'
+
 
 export default function EditorChoiceGames({ applications }) {
   return (
-    <>
+    <Main>
       <NextSeo title="Editor's Choice Games" />
       <ApplicationCollection
         title="Editor's Choice Games"
         applications={applications}
       />
-    </>
+    </Main>
   )
 }
 

--- a/pages/apps/collection/popular.tsx
+++ b/pages/apps/collection/popular.tsx
@@ -1,17 +1,18 @@
 import { GetStaticProps } from 'next'
-
-import ApplicationCollection from '../../../src/components/application/Collection'
-import fetchCollection from '../../../src/fetchers'
-import { Collections } from '../../../src/types/Collection'
-import { Appstream } from '../../../src/types/Appstream'
 import { NextSeo } from 'next-seo'
+import ApplicationCollection from '../../../src/components/application/Collection'
+import Main from '../../../src/components/layout/Main'
+import fetchCollection from '../../../src/fetchers'
+import { Appstream } from '../../../src/types/Appstream'
+import { Collections } from '../../../src/types/Collection'
+
 
 export default function PopularApps({ applications }) {
   return (
-    <>
+    <Main>
       <NextSeo title='Popular Apps' />
       <ApplicationCollection title='Popular Apps' applications={applications} />
-    </>
+    </Main>
   )
 }
 

--- a/pages/apps/collection/recently-updated.tsx
+++ b/pages/apps/collection/recently-updated.tsx
@@ -1,20 +1,21 @@
 import { GetStaticProps } from 'next'
-
-import ApplicationCollection from '../../../src/components/application/Collection'
-import fetchCollection from '../../../src/fetchers'
-import { Collections } from '../../../src/types/Collection'
-import { Appstream } from '../../../src/types/Appstream'
 import { NextSeo } from 'next-seo'
+import ApplicationCollection from '../../../src/components/application/Collection'
+import Main from '../../../src/components/layout/Main'
+import fetchCollection from '../../../src/fetchers'
+import { Appstream } from '../../../src/types/Appstream'
+import { Collections } from '../../../src/types/Collection'
+
 
 export default function RecentlyUpdatedApps({ applications }) {
   return (
-    <>
+    <Main>
       <NextSeo title='Recently Updated Apps' />
       <ApplicationCollection
         title='Recently Updated Apps'
         applications={applications}
       />
-    </>
+    </Main>
   )
 }
 

--- a/pages/apps/search/[query].tsx
+++ b/pages/apps/search/[query].tsx
@@ -1,6 +1,7 @@
 import { NextSeo } from 'next-seo'
 import { useRouter } from 'next/router'
 import Collection from '../../../src/components/application/Collection'
+import Main from '../../../src/components/layout/Main'
 import { useSearchQuery } from '../../../src/hooks/useSearchQuery'
 
 export default function Search() {
@@ -10,7 +11,7 @@ export default function Search() {
   const searchResult = useSearchQuery(query as string)
 
   return (
-    <>
+    <Main>
       <NextSeo title={`Search for ${query}`} />
 
       {searchResult && (
@@ -19,6 +20,6 @@ export default function Search() {
           applications={searchResult}
         />
       )}
-    </>
+    </Main>
   )
 }

--- a/pages/login/github.tsx
+++ b/pages/login/github.tsx
@@ -1,6 +1,8 @@
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import Main from '../../src/components/layout/Main';
+import { getUserData } from '../../src/context/actions';
+import { useUserDispatch } from '../../src/context/user-info';
 import { LOGIN_PROVIDERS_URL } from '../../src/env';
 import Error from '../_error';
 
@@ -11,6 +13,8 @@ export default function AuthReturnPage() {
   // Use state to rerender when request resolves
   const [status, setStatus] = useState(null)
   const [feedback, setFeedback] = useState('Awaiting server')
+
+  const dispatch = useUserDispatch()
 
   useEffect(() => {
     // Router must be ready to access query parameters
@@ -36,9 +40,9 @@ export default function AuthReturnPage() {
         })
       })
 
-      // TODO store logged-in user info client-side
       if (res.ok) {
         // May just want to redirect on successful login
+        getUserData(dispatch)
         setFeedback('Success')
       } else {
         // Bad response codes

--- a/pages/login/github.tsx
+++ b/pages/login/github.tsx
@@ -1,6 +1,6 @@
 import { NextSeo } from 'next-seo';
 import { useRouter } from 'next/router';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import Main from '../../src/components/layout/Main';
 import { login } from '../../src/context/actions';
 import { useUserContext, useUserDispatch } from '../../src/context/user-info';
@@ -9,15 +9,18 @@ export default function AuthReturnPage() {
   // Must access query params to POST to backend for verification with GitHub
   const router = useRouter()
 
+  // Send only one request, prevent infinite loops
+  const [sent, setSent] = useState(false)
+
   const user = useUserContext()
   const dispatch = useUserDispatch()
 
-  // Redirect to userpage once logged in
-  if (user.info) {
-    router.push('/userpage')
-  }
-
   useEffect(() => {
+    // Redirect to userpage once logged in
+    if (user.info && !user.loading) {
+      router.push('/userpage')
+    }
+
     // Router must be ready to access query parameters
     // This must be a dependency to ensure only runs once
     if (!router.isReady) { return }
@@ -28,8 +31,11 @@ export default function AuthReturnPage() {
       return
     }
 
-    login(dispatch, router.query)
-  }, [router, dispatch])
+    if (!sent) {
+      setSent(true)
+      login(dispatch, router.query)
+    }
+  }, [router, dispatch, user, sent])
 
   return (
     <Main>

--- a/pages/login/github.tsx
+++ b/pages/login/github.tsx
@@ -1,11 +1,10 @@
-import { GetStaticProps } from 'next';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import Main from '../../src/components/layout/Main';
 import { LOGIN_PROVIDERS_URL } from '../../src/env';
 import Error from '../_error';
 
-export default function AuthReturnPage({ endpoint }) {
+export default function AuthReturnPage() {
   // Must access query params to POST to backend for verification with GitHub
   const router = useRouter()
 
@@ -49,9 +48,9 @@ export default function AuthReturnPage({ endpoint }) {
     }
 
     // Catches any unexpected network errors
-    postRequest(`${endpoint}/github`)
+    postRequest(`${LOGIN_PROVIDERS_URL}/github`)
       .catch(() => setFeedback('Network error, please try again'))
-  }, [router, endpoint])
+  }, [router])
 
   if (status) {
     return <Error statusCode={status}></Error>
@@ -63,14 +62,4 @@ export default function AuthReturnPage({ endpoint }) {
       <p>{feedback}</p>
     </Main>
   )
-}
-
-export const getStaticProps: GetStaticProps = () => {
-  // Get envrionment variable driven value at build time for client use
-  // NOTE: May want to just use NEXT_PUBLIC prefix for API URL
-  return {
-    props: {
-      endpoint: LOGIN_PROVIDERS_URL
-    }
-  }
 }

--- a/pages/login/github.tsx
+++ b/pages/login/github.tsx
@@ -1,6 +1,7 @@
 import { NextSeo } from 'next-seo';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
+import FeedbackMessage from '../../src/components/FeedbackMessage';
 import Main from '../../src/components/layout/Main';
 import { login } from '../../src/context/actions';
 import { useUserContext, useUserDispatch } from '../../src/context/user-info';
@@ -11,6 +12,7 @@ export default function AuthReturnPage() {
 
   // Send only one request, prevent infinite loops
   const [sent, setSent] = useState(false)
+  const [error, setError] = useState('')
 
   const user = useUserContext()
   const dispatch = useUserDispatch()
@@ -33,13 +35,14 @@ export default function AuthReturnPage() {
 
     if (!sent) {
       setSent(true)
-      login(dispatch, router.query)
+      login(dispatch, setError, router.query)
     }
   }, [router, dispatch, user, sent])
 
   return (
     <Main>
       <NextSeo title='Login' noindex={true}></NextSeo>
+      {error ? <FeedbackMessage success={false} message={error} /> : <></>}
     </Main>
   )
 }

--- a/pages/login/github.tsx
+++ b/pages/login/github.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import FeedbackMessage from '../../src/components/FeedbackMessage';
 import Main from '../../src/components/layout/Main';
+import Spinner from '../../src/components/Spinner';
 import { login } from '../../src/context/actions';
 import { useUserContext, useUserDispatch } from '../../src/context/user-info';
 
@@ -42,6 +43,7 @@ export default function AuthReturnPage() {
   return (
     <Main>
       <NextSeo title='Login' noindex={true}></NextSeo>
+      {user.loading ? <Spinner size={200} /> : <></>}
       {error ? <FeedbackMessage success={false} message={error} /> : <></>}
     </Main>
   )

--- a/pages/login/github.tsx
+++ b/pages/login/github.tsx
@@ -1,69 +1,39 @@
+import { NextSeo } from 'next-seo';
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import Main from '../../src/components/layout/Main';
-import { getUserData } from '../../src/context/actions';
-import { useUserDispatch } from '../../src/context/user-info';
-import { LOGIN_PROVIDERS_URL } from '../../src/env';
-import Error from '../_error';
+import { login } from '../../src/context/actions';
+import { useUserContext, useUserDispatch } from '../../src/context/user-info';
 
 export default function AuthReturnPage() {
   // Must access query params to POST to backend for verification with GitHub
   const router = useRouter()
 
-  // Use state to rerender when request resolves
-  const [status, setStatus] = useState(null)
-  const [feedback, setFeedback] = useState('Awaiting server')
-
+  const user = useUserContext()
   const dispatch = useUserDispatch()
+
+  // Redirect to userpage once logged in
+  if (user.info) {
+    router.push('/userpage')
+  }
 
   useEffect(() => {
     // Router must be ready to access query parameters
     // This must be a dependency to ensure only runs once
     if (!router.isReady) { return }
 
-    // Show 404 if user tries some kind of directory traversal
+    // Redirect to home if user tries some kind of directory traversal
     if (router.query.code == null || router.query.state == null) {
-      setStatus(404)
+      router.push('/')
       return
     }
 
-    const postRequest = async (url: string) => {
-      const res = await fetch(url, {
-        method: 'POST',
-        credentials: 'include', // Must use the session cookie
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          code: router.query.code,
-          state: router.query.state,
-        })
-      })
+    login(dispatch, router.query)
+  }, [router, dispatch])
 
-      if (res.ok) {
-        // May just want to redirect on successful login
-        getUserData(dispatch)
-        setFeedback('Success')
-      } else {
-        // Bad response codes
-        // Note: Some of these come with an error message from backend we could display
-        setStatus(res.status)
-      }
-    }
-
-    // Catches any unexpected network errors
-    postRequest(`${LOGIN_PROVIDERS_URL}/github`)
-      .catch(() => setFeedback('Network error, please try again'))
-  }, [router])
-
-  if (status) {
-    return <Error statusCode={status}></Error>
-  }
-
-  // Only show error page if status is set
   return (
     <Main>
-      <p>{feedback}</p>
+      <NextSeo title='Login' noindex={true}></NextSeo>
     </Main>
   )
 }

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -30,7 +30,9 @@ export default function DeveloperLoginPortal({ providers }) {
 export const getStaticProps: GetStaticProps = async () => {
   const providers: LoginProvider[] = await fetchLoginProviders()
 
+  // If request failed at build time, this page becomes a 404
   return {
+    notFound: !providers,
     props: {
       providers,
     }

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -1,11 +1,23 @@
 import { GetStaticProps } from 'next'
 import { NextSeo } from 'next-seo'
 import Main from '../../src/components/layout/Main'
+import Router from 'next/router'
+import { useEffect } from 'react'
 import LoginProviders from '../../src/components/login/Providers'
+import { useUserContext } from '../../src/context/user-info'
 import { fetchLoginProviders } from '../../src/fetchers'
 import { LoginProvider } from '../../src/types/Login'
 
 export default function DeveloperLoginPortal({ providers }) {
+  const user = useUserContext()
+
+  useEffect(() => {
+    // Already logged in, just redirect to userpage
+    if (user.info && !user.loading) {
+      Router.push('/userpage')
+    }
+  }, [user])
+
   return (
     <Main>
       <NextSeo title='Developer Login' />

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -1,0 +1,26 @@
+import { GetStaticProps } from 'next'
+import { NextSeo } from 'next-seo'
+import Main from '../../src/components/layout/Main'
+import LoginProviders from '../../src/components/login/Providers'
+import { fetchLoginProviders } from '../../src/fetchers'
+import { LoginProvider } from '../../src/types/Login'
+
+export default function DeveloperLoginPortal({ providers }) {
+  return (
+    <Main>
+      <NextSeo title='Developer Login' />
+      <LoginProviders providers={providers}/>
+    </Main>
+  )
+}
+
+// Providers won't change often so fetch at build time for now
+export const getStaticProps: GetStaticProps = async () => {
+  const providers: LoginProvider[] = await fetchLoginProviders()
+
+  return {
+    props: {
+      providers,
+    }
+  }
+}

--- a/pages/userpage.module.scss
+++ b/pages/userpage.module.scss
@@ -1,0 +1,7 @@
+.userArea {
+  display: flex;
+  flex-direction: column;
+  row-gap: 15px;
+
+  padding: 10px;
+}

--- a/pages/userpage.tsx
+++ b/pages/userpage.tsx
@@ -5,6 +5,7 @@ import Main from '../src/components/layout/Main'
 import LogoutButton from '../src/components/login/LogoutButton'
 import Spinner from '../src/components/Spinner'
 import UserDetails from '../src/components/user/Details'
+import UserApps from '../src/components/user/UserApps'
 import { useUserContext } from '../src/context/user-info'
 import styles from './userpage.module.scss'
 
@@ -22,10 +23,11 @@ export default function Userpage() {
   if (user.loading || !user.info) {
     content = <Spinner size={150} />
   } else {
+    // Buttons above apps so they're on screen when page loads (for action visibility)
     content = <div className={styles.userArea}>
       <UserDetails />
-      {/* TODO: Flatpaks here */}
       <div><LogoutButton /></div>
+      <UserApps />
     </div>
   }
 

--- a/pages/userpage.tsx
+++ b/pages/userpage.tsx
@@ -1,0 +1,22 @@
+import { NextSeo } from 'next-seo'
+import Router from 'next/router'
+import Main from '../src/components/layout/Main'
+import LogoutButton from '../src/components/login/LogoutButton'
+import UserDetails from '../src/components/user/Details'
+import { useUserContext } from '../src/context/user-info'
+import styles from './userpage.module.scss'
+
+export default function Userpage() {
+  const user = useUserContext()
+
+  return (
+    <Main>
+      <NextSeo title='User page' noindex={true} />
+      <div className={styles.userArea}>
+        <UserDetails />
+        {/* TODO: Flatpaks here */}
+        <div><LogoutButton /></div>
+      </div>
+    </Main>
+  )
+}

--- a/pages/userpage.tsx
+++ b/pages/userpage.tsx
@@ -1,8 +1,9 @@
 import { NextSeo } from 'next-seo'
 import Router from 'next/router'
-import { useEffect } from 'react'
+import { ReactElement, useEffect } from 'react'
 import Main from '../src/components/layout/Main'
 import LogoutButton from '../src/components/login/LogoutButton'
+import Spinner from '../src/components/Spinner'
 import UserDetails from '../src/components/user/Details'
 import { useUserContext } from '../src/context/user-info'
 import styles from './userpage.module.scss'
@@ -17,14 +18,21 @@ export default function Userpage() {
     }
   }, [user])
 
+  let content: ReactElement
+  if (user.loading || !user.info) {
+    content = <Spinner size={150} />
+  } else {
+    content = <div className={styles.userArea}>
+      <UserDetails />
+      {/* TODO: Flatpaks here */}
+      <div><LogoutButton /></div>
+    </div>
+  }
+
   return (
     <Main>
       <NextSeo title='User page' noindex={true} />
-      <div className={styles.userArea}>
-        <UserDetails />
-        {/* TODO: Flatpaks here */}
-        <div><LogoutButton /></div>
-      </div>
+      {content}
     </Main>
   )
 }

--- a/pages/userpage.tsx
+++ b/pages/userpage.tsx
@@ -1,5 +1,6 @@
 import { NextSeo } from 'next-seo'
 import Router from 'next/router'
+import { useEffect } from 'react'
 import Main from '../src/components/layout/Main'
 import LogoutButton from '../src/components/login/LogoutButton'
 import UserDetails from '../src/components/user/Details'
@@ -8,6 +9,13 @@ import styles from './userpage.module.scss'
 
 export default function Userpage() {
   const user = useUserContext()
+
+  // Nothing to show if not logged in, return to home
+  useEffect(() => {
+    if (!user.info && !user.loading) {
+      Router.push('/')
+    }
+  }, [user])
 
   return (
     <Main>

--- a/src/components/FeedbackMessage.module.scss
+++ b/src/components/FeedbackMessage.module.scss
@@ -1,0 +1,21 @@
+.success {
+  background-color: palegreen;
+  border-color: darkgreen;
+}
+
+.failure {
+  background-color: palevioletred;
+  border-color: darkred;
+}
+
+.feedback {
+  border-style: solid;
+  border-width: 2px;
+  border-radius: var(--border-radius);
+
+  color: var(--text-primary) !important;
+
+  // Fit to message content
+  display: inline-block;
+  padding: 5px;
+}

--- a/src/components/FeedbackMessage.tsx
+++ b/src/components/FeedbackMessage.tsx
@@ -1,0 +1,20 @@
+import { FunctionComponent } from 'react'
+import styles from './FeedbackMessage.module.scss'
+
+interface Props {
+  success: boolean,
+  message: string,
+}
+
+const FeedbackMessage: FunctionComponent<Props> = ({ success, message }) => {
+  const status = success ? styles.success : styles.failure
+  const classes = `${styles.feedback} ${status}`
+
+  return (
+    <div className={classes}>
+      <p>{message}</p>
+    </div>
+  )
+}
+
+export default FeedbackMessage

--- a/src/components/Spinner.module.scss
+++ b/src/components/Spinner.module.scss
@@ -1,0 +1,34 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  .spinner {
+    .back {
+      fill: var(--bg-color-secondary)
+    }
+
+    .front {
+      fill: var(--color-primary)
+    }
+
+    .center {
+      fill: var(--bg-color-primary)
+    }
+
+    transform-origin: 50% 50%;
+    animation-name: spin;
+    animation-iteration-count: infinite;
+    animation-duration: 3s;
+    animation-timing-function: linear;
+  }
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg)
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -1,0 +1,31 @@
+import { FunctionComponent } from 'react'
+import styles from './Spinner.module.scss'
+
+interface Props {
+  size: number, // Size in pixels
+  text?: string, // Message to display underneath
+}
+
+const Spinner: FunctionComponent<Props> = ({ size, text='Loading...' }) => {
+
+  // SVG of a circle with a highlighted 90 degree arc on the border
+  // Made to spin via CSS animation
+  return (
+    // Spinner will always be centered and padded relative to its size
+    <div className={styles.container} style={{ padding: `${size/2}px` }}>
+      <svg className={styles.spinner}
+        width={size}
+        height={size}
+        viewBox='0 0 100 100'
+        xmlns='http://www.w3.org/2000/svg'
+      >
+        <circle cx='50' cy='50' r='50' className={styles.back} />
+        <path className={styles.front} d='M50,50l0,50a50,50 0 0 1 -50,-50z' />
+        <circle cx='50' cy='50' r='45' className={styles.center} />
+      </svg>
+      <p>{text}</p>
+    </div>
+  )
+}
+
+export default Spinner

--- a/src/components/application/Collection.tsx
+++ b/src/components/application/Collection.tsx
@@ -30,26 +30,24 @@ const ApplicationCollection: FunctionComponent<Props> = ({
   )
 
   return (
-    <Main>
-      <div className='main-container'>
-        <div className={styles.collectionWrapper}>
-          <section className={styles.applicationsCollection}>
-            <div className={styles.collection}>
-              <h2>{title}</h2>
-              <p>{applications.length} results</p>
+    <div className='main-container'>
+      <div className={styles.collectionWrapper}>
+        <section className={styles.applicationsCollection}>
+          <div className={styles.collection}>
+            <h2>{title}</h2>
+            <p>{applications.length} results</p>
 
-              <div className={styles.applications}>
-                {pagedApplications.map((app) => (
-                  <ApplicationCard key={app.id} application={app} />
-                ))}
-              </div>
-
-              <Pagination pages={pages} currentPage={page} />
+            <div className={styles.applications}>
+              {pagedApplications.map((app) => (
+                <ApplicationCard key={app.id} application={app} />
+              ))}
             </div>
-          </section>
-        </div>
+
+            <Pagination pages={pages} currentPage={page} />
+          </div>
+        </section>
       </div>
-    </Main>
+    </div>
   )
 }
 

--- a/src/components/layout/Footer.module.scss
+++ b/src/components/layout/Footer.module.scss
@@ -8,7 +8,7 @@
     margin-left: auto;
     margin-right: auto;
     display: grid;
-    grid-template-columns: 1fr 1fr 1fr 1fr;
+    grid-template-columns: repeat(5,1fr);
     gap: 0px 0px;
     justify-items: center;
     max-width: 900px;

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import styles from './Footer.module.scss'
+import LoginStatus from '../login/Status'
 
 const Footer = () => (
   <footer id={styles.footer}>
@@ -104,6 +105,10 @@ const Footer = () => (
             </a>
           </div>
         </div>
+      </div>
+
+      <div className={styles.footerSection}>
+        <LoginStatus />
       </div>
     </div>
   </footer>

--- a/src/components/login/LogoutButton.tsx
+++ b/src/components/login/LogoutButton.tsx
@@ -1,18 +1,24 @@
-import { FunctionComponent, useState, useEffect } from 'react'
+import { FunctionComponent, useEffect, useState } from 'react'
 import { logout } from '../../context/actions'
 import { useUserDispatch } from '../../context/user-info'
 import Button from '../Button'
+import FeedbackMessage from '../FeedbackMessage'
 
 const LogoutButton: FunctionComponent = () => {
   // Using state to prevent user repeatedly initating fetches
   const [clicked, setClicked] = useState(false)
-
+  const [error, setError] = useState('')
   const dispatch = useUserDispatch()
 
   // Only make a request on first click
   useEffect(() => {
-    if (clicked) { logout(dispatch) }
+    if (clicked) { logout(dispatch, setError) }
   }, [dispatch, clicked])
+
+  // There may have been a network error
+  if (error) {
+    return <FeedbackMessage success={false} message={error} />
+  }
 
   return (
     <Button onClick={() => setClicked(true)} type='primary'>

--- a/src/components/login/LogoutButton.tsx
+++ b/src/components/login/LogoutButton.tsx
@@ -1,0 +1,24 @@
+import { FunctionComponent, useState, useEffect } from 'react'
+import { logout } from '../../context/actions'
+import { useUserDispatch } from '../../context/user-info'
+import Button from '../Button'
+
+const LogoutButton: FunctionComponent = () => {
+  // Using state to prevent user repeatedly initating fetches
+  const [clicked, setClicked] = useState(false)
+
+  const dispatch = useUserDispatch()
+
+  // Only make a request on first click
+  useEffect(() => {
+    if (clicked) { logout(dispatch) }
+  }, [dispatch, clicked])
+
+  return (
+    <Button onClick={() => setClicked(true)} type='primary'>
+      Log Out
+    </Button>
+  )
+}
+
+export default LogoutButton

--- a/src/components/login/ProviderLink.tsx
+++ b/src/components/login/ProviderLink.tsx
@@ -1,0 +1,48 @@
+import { FunctionComponent, useState, useEffect } from 'react'
+import { LoginProvider, LoginRedirect } from '../../types/Login'
+import styles from './Providers.module.scss'
+
+interface Props {
+  provider: LoginProvider,
+}
+
+const ProviderLink: FunctionComponent<Props> = ({
+  provider
+}) => {
+  // Using state to prevent user repeatedly initating fetches by clicking
+  // while loading
+  const [clicked, setClicked] = useState(false)
+
+  // When user clicks a provider, a redirect is fetched to initiate login flow
+  useEffect(() => {
+    const redirect = async (url: string) => {
+      const res = await fetch(url, {
+        credentials: 'include', // Must use the session cookie sent back
+        cache: 'no-store', // Redirects are unique each time
+      })
+
+      if (res.ok) {
+        const data: LoginRedirect = await res.json()
+        window.location.href = data.redirect
+      } else {
+        // TODO: redirect to user page if logged in, or show feedback
+        window.location.href = '/'
+      }
+    }
+
+    // Only make a request on first click
+    if (clicked) {
+      // TODO: catch network errors and show some feedback
+      redirect(provider.method)
+    }
+  }, [clicked, provider.method])
+
+  return (
+    <button className={styles.provider} onClick={() => setClicked(true)}>
+      <img src={provider.button} width='60' height='60' alt=''></img>
+      {provider.text}
+    </button>
+  )
+}
+
+export default ProviderLink

--- a/src/components/login/ProviderLink.tsx
+++ b/src/components/login/ProviderLink.tsx
@@ -21,12 +21,10 @@ const ProviderLink: FunctionComponent<Props> = ({
         cache: 'no-store', // Redirects are unique each time
       })
 
+      // TODO something with bad responses
       if (res.ok) {
         const data: LoginRedirect = await res.json()
         window.location.href = data.redirect
-      } else {
-        // TODO: redirect to user page if logged in, or show feedback
-        window.location.href = '/'
       }
     }
 

--- a/src/components/login/Providers.module.scss
+++ b/src/components/login/Providers.module.scss
@@ -1,0 +1,36 @@
+.providers {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  .provider {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+
+    margin-top: 20px;
+    padding: 10px;
+
+    border-radius: var(--border-radius);
+    color: var(--text-primary) !important;
+    background-color: var(--bg-color-secondary);
+
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.03), 0 1px 3px 1px rgba(0, 0, 0, 0.07),
+    0 2px 6px 2px rgba(0, 0, 0, 0.03);
+
+    &:hover {
+      cursor: pointer;
+      filter: brightness(0.96);
+      color: var(--white-10);
+      text-decoration: none;
+    }
+
+    &:active {
+      background-color: var(--bg-color-primary);
+    }
+
+    img {
+      margin-right: 10px;
+    }
+  }
+}

--- a/src/components/login/Providers.tsx
+++ b/src/components/login/Providers.tsx
@@ -1,0 +1,22 @@
+import { FunctionComponent } from 'react'
+import { LoginProvider } from '../../types/Login'
+import ProviderLink from './ProviderLink'
+import styles from './Providers.module.scss'
+
+interface Props {
+  providers: LoginProvider[],
+}
+
+const LoginProviders: FunctionComponent<Props> = ({
+  providers,
+}) => {
+  const links = providers.map(p => <ProviderLink provider={p} key={p.method} />)
+
+  return (
+    <div className={styles.providers}>
+      {links}
+    </div>
+  )
+}
+
+export default LoginProviders

--- a/src/components/login/Status.module.scss
+++ b/src/components/login/Status.module.scss
@@ -1,0 +1,18 @@
+.loginStatus {
+  width: 100%;
+
+  .user {
+    display: flex;
+    align-items: center;
+    background-color: rgba(255,255,255, 0.2);
+    border-radius: var(--border-radius);
+    padding: 5px;
+    column-gap: 10px;
+
+    .userAvatar {
+      width: 50px;
+      height: 50px;
+      border-radius: 25px;
+    }
+  }
+}

--- a/src/components/login/Status.tsx
+++ b/src/components/login/Status.tsx
@@ -1,0 +1,34 @@
+import Link from 'next/link'
+import { FunctionComponent, ReactElement } from 'react'
+import { useUserContext } from '../../context/user-info'
+import styles from './Status.module.scss'
+
+
+const LoginStatus: FunctionComponent = () => {
+  const user = useUserContext()
+
+  let status: ReactElement;
+  if (user.info) {
+    status = <>
+      <h4>Logged in as:</h4>
+
+      <Link href="/userpage" passHref>
+        <a className={styles.user}>
+        <img
+          src={user.info.github_avatar}
+          className={styles.userAvatar}
+        />
+        {user.info.displayname}
+        </a>
+      </Link>
+    </>
+  } else {
+    status = <Link href="/login" passHref><a>Developer login</a></Link>
+  }
+
+  return <div className={styles.loginStatus}>
+    {status}
+  </div>
+}
+
+export default LoginStatus

--- a/src/components/user/Details.module.scss
+++ b/src/components/user/Details.module.scss
@@ -1,0 +1,30 @@
+.details {
+  display: flex;
+  flex-direction: row;
+
+  padding: 10px;
+
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.03), 0 1px 3px 1px rgba(0, 0, 0, 0.07),
+    0 2px 6px 2px rgba(0, 0, 0, 0.03);
+
+  color: var(--text-primary) !important;
+  background-color: var(--bg-color-secondary);
+  border-radius: var(--border-radius);
+
+  .avatar {
+    width: 140px;
+    height: 140px;
+    border-radius: 70px;
+  }
+
+  .textDetails {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: flex-start;
+    align-content: flex-start;
+    gap: 5px;
+
+    margin-left: 10px;
+  }
+}

--- a/src/components/user/Details.tsx
+++ b/src/components/user/Details.tsx
@@ -1,0 +1,34 @@
+import { FunctionComponent } from 'react'
+import { useUserContext } from '../../context/user-info'
+import styles from './Details.module.scss'
+
+const UserDetails: FunctionComponent = () => {
+  const user = useUserContext()
+
+  // Nothing to show if not logged in
+  if (!user.info) {
+    return <></>
+  }
+
+  const {
+    github_avatar,
+    github_login,
+    displayname,
+    "dev-flatpaks": flatpaks
+  } = user.info
+
+  return (
+    <div className={styles.details}>
+      <img
+        src={github_avatar}
+        className={styles.avatar}
+      />
+      <div className={styles.textDetails}>
+        <h2>{displayname}</h2>
+        <p>GitHub Account: <a href={`https://github.com/${github_login}`}>@{github_login}</a></p>
+      </div>
+    </div>
+  )
+}
+
+export default UserDetails

--- a/src/components/user/UserApps.tsx
+++ b/src/components/user/UserApps.tsx
@@ -1,0 +1,56 @@
+import { FunctionComponent, useEffect, useState } from 'react'
+import { useUserContext } from '../../context/user-info'
+import { APP_DETAILS } from '../../env'
+import { Appstream } from '../../types/Appstream'
+import ApplicationCollection from '../application/Collection'
+import Spinner from '../Spinner'
+
+async function getAppsInfo(
+  appIds: string[],
+  setLoading: (a: boolean) => void,
+  setApps: (a: Appstream[]) => void,
+) {
+  setLoading(true)
+
+  const responses = await Promise.all(
+    appIds.map(id => fetch(`${APP_DETAILS(id)}`))
+  )
+  const apps = await Promise.all(responses.map(res => res.json()))
+
+  setApps(apps)
+  setLoading(false)
+}
+
+const UserApps: FunctionComponent = () => {
+  const user = useUserContext()
+  const [apps, setApps] = useState([])
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!user.info) return
+
+    const { "dev-flatpaks": appIds } = user.info
+    getAppsInfo(appIds, setLoading, setApps)
+  }, [user.info])
+
+  // Nothing to show if not logged in
+  if (!user.info) {
+    return <></>
+  }
+
+  if (loading) {
+    return <Spinner
+      size={100}
+      text='Loading user apps...'
+    />
+  }
+
+  return (
+    <ApplicationCollection
+      title='Your Apps'
+      applications={apps}
+    />
+  )
+}
+
+export default UserApps

--- a/src/context/actions.ts
+++ b/src/context/actions.ts
@@ -1,0 +1,26 @@
+import { Dispatch } from "react";
+import { USER_INFO_URL } from "../env";
+import { UserStateAction } from "../types/Login";
+
+export async function getUserData(dispatch: Dispatch<UserStateAction>) {
+  // Indicate the user data is being fetched
+  dispatch({type: 'loading'})
+
+  // Gets data for user with current session cookie
+  const res = await fetch(USER_INFO_URL, { credentials: 'include' })
+
+  // 403 indicates not currently logged in
+  if (res.status === 403) {
+    dispatch({type: 'logout'})
+  } else {
+    const info = await res.json()
+    dispatch({
+      type: 'login',
+      info
+    })
+  }
+}
+
+export function logout(dispatch: Dispatch<UserStateAction>) {
+  dispatch({type: 'logout'})
+}

--- a/src/context/actions.ts
+++ b/src/context/actions.ts
@@ -1,6 +1,6 @@
 import { ParsedUrlQuery } from "querystring";
 import { Dispatch } from "react";
-import { LOGIN_PROVIDERS_URL, USER_INFO_URL } from "../env";
+import { LOGIN_PROVIDERS_URL, LOGOUT_URL, USER_INFO_URL } from "../env";
 import { UserStateAction } from "../types/Login";
 
 export async function login(dispatch: Dispatch<UserStateAction>, query: ParsedUrlQuery) {
@@ -45,6 +45,15 @@ export async function getUserData(dispatch: Dispatch<UserStateAction>) {
   }
 }
 
-export function logout(dispatch: Dispatch<UserStateAction>) {
-  dispatch({type: 'logout'})
+export async function logout(dispatch: Dispatch<UserStateAction>) {
+  dispatch({type: 'loading'})
+
+  const res = await fetch(LOGOUT_URL, {
+    method: 'POST',
+    credentials: 'include',
+  })
+
+  if (res.ok) {
+    dispatch({type: 'logout'})
+  }
 }

--- a/src/context/actions.ts
+++ b/src/context/actions.ts
@@ -1,6 +1,30 @@
+import { ParsedUrlQuery } from "querystring";
 import { Dispatch } from "react";
-import { USER_INFO_URL } from "../env";
+import { LOGIN_PROVIDERS_URL, USER_INFO_URL } from "../env";
 import { UserStateAction } from "../types/Login";
+
+export async function login(dispatch: Dispatch<UserStateAction>, query: ParsedUrlQuery) {
+  dispatch({type: 'loading'})
+
+  const res = await fetch(`${LOGIN_PROVIDERS_URL}/github`, {
+    method: 'POST',
+    credentials: 'include', // Must use the session cookie
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      code: query.code,
+      state: query.state,
+    })
+  })
+
+  if (res.ok) {
+    getUserData(dispatch)
+  } else {
+    // Note: Some of these come with an error message from backend we could display
+    dispatch({type: 'logout'})
+  }
+}
 
 export async function getUserData(dispatch: Dispatch<UserStateAction>) {
   // Indicate the user data is being fetched

--- a/src/context/reducer.ts
+++ b/src/context/reducer.ts
@@ -8,6 +8,11 @@ export function contextReducer(state: UserState, action: UserStateAction): UserS
         ...state,
         loading: true
       }
+    case 'interrupt':
+      return {
+        ...state,
+        loading: false
+      }
     case 'login':
       return {
         loading: false,

--- a/src/context/reducer.ts
+++ b/src/context/reducer.ts
@@ -1,0 +1,23 @@
+import { UserState, UserStateAction } from "../types/Login"
+
+export function contextReducer(state: UserState, action: UserStateAction): UserState {
+  switch (action.type) {
+    case 'loading':
+      // Reducers should not mutate the current state object
+      return {
+        ...state,
+        loading: true
+      }
+    case 'login':
+      return {
+        loading: false,
+        info: action.info
+      }
+    case 'logout':
+      return {
+        loading: false
+      }
+    default:
+      return state
+  }
+}

--- a/src/context/user-info.tsx
+++ b/src/context/user-info.tsx
@@ -1,0 +1,34 @@
+import { createContext, Dispatch, useContext, useEffect, useReducer } from 'react';
+import { UserState, UserStateAction } from '../types/Login'
+import { getUserData } from './actions';
+import { contextReducer } from './reducer';
+
+const initialState = { loading: true }
+
+export const UserContext = createContext<UserState>(initialState);
+export const UserDispatchContext = createContext<Dispatch<UserStateAction>>(null);
+
+export const UserInfoProvider = ({ children }) => {
+  const [user, dispatch] = useReducer(contextReducer, initialState)
+
+  // Fetch the user data only the first time the provider is created
+  // This works thanks to Next.js Link components, as soon as a new
+  // session is created this will re-fetch
+  useEffect(() => { getUserData(dispatch) }, [])
+
+  return (
+    <UserContext.Provider value={user}>
+      <UserDispatchContext.Provider value={dispatch}>
+        {children}
+      </UserDispatchContext.Provider>
+    </UserContext.Provider>
+  )
+}
+
+// Custom hooks to use the contexts make code cleaner elsewhere
+export function useUserContext() {
+  return useContext(UserContext)
+}
+export function useUserDispatch() {
+  return useContext(UserDispatchContext)
+}

--- a/src/env.ts
+++ b/src/env.ts
@@ -31,3 +31,5 @@ export const FEED_NEW_URL: string = `${BASE_URI}/feed/new`
 export const APPS_IN_PREVIEW_COUNT: number = 6
 
 export const IMAGE_BASE_URL: string = `${process.env.NEXT_PUBLIC_SITE_BASE_URI}/img/`
+
+export const LOGIN_PROVIDERS_URL: string = `${BASE_URI}/auth/login`

--- a/src/env.ts
+++ b/src/env.ts
@@ -33,3 +33,5 @@ export const APPS_IN_PREVIEW_COUNT: number = 6
 export const IMAGE_BASE_URL: string = `${process.env.NEXT_PUBLIC_SITE_BASE_URI}/img/`
 
 export const LOGIN_PROVIDERS_URL: string = `${BASE_URI}/auth/login`
+export const USER_INFO_URL: string = `${BASE_URI}/auth/userinfo`
+export const LOGOUT_URL: string = `${BASE_URI}/auth/logout`

--- a/src/fetchers.ts
+++ b/src/fetchers.ts
@@ -190,7 +190,20 @@ export async function fetchSearchQuery(query: string) {
 }
 
 export async function fetchLoginProviders(): Promise<LoginProvider[]> {
-  const providersRes = await fetch(LOGIN_PROVIDERS_URL)
+  // Ensure problem is visible in logs if fetch fails at build
+  let providersRes: Response
+  try {
+    providersRes = await fetch(LOGIN_PROVIDERS_URL)
+
+    if (!providersRes.ok) {
+      console.log(`No login providers data fetched, status ${providersRes.status}`)
+      return null
+    }
+  } catch (error) {
+    console.log(error)
+    return null
+  }
+
   const providers = await providersRes.json()
 
   // Creating full URL here since env variable not available client-side

--- a/src/fetchers.ts
+++ b/src/fetchers.ts
@@ -1,6 +1,7 @@
 import { Appstream } from './types/Appstream'
 import { Collection, Collections } from './types/Collection'
 import { Category } from './types/Category'
+import { LoginProvider } from './types/Login'
 
 import {
   POPULAR_URL,
@@ -15,6 +16,7 @@ import {
   STATS,
   DEVELOPER_URL,
   DEVELOPERS_URL,
+  LOGIN_PROVIDERS_URL,
 } from './env'
 import { Summary } from './types/Summary'
 import { AppStats } from './types/AppStats'
@@ -185,4 +187,15 @@ export async function fetchSearchQuery(query: string) {
   console.log("\nSearch for query: '", query, "' fetched")
 
   return appList.filter((item) => Boolean(item))
+}
+
+export async function fetchLoginProviders(): Promise<LoginProvider[]> {
+  const providersRes = await fetch(LOGIN_PROVIDERS_URL)
+  const providers = await providersRes.json()
+
+  // Creating full URL here since env variable not available client-side
+  return providers.map((p: LoginProvider) => {
+    p.method = `${LOGIN_PROVIDERS_URL}/${p.method}`
+    return p
+  })
 }

--- a/src/types/Login.ts
+++ b/src/types/Login.ts
@@ -1,0 +1,9 @@
+export interface LoginProvider {
+  method: string,
+  button: string,
+  text: string,
+}
+
+export interface LoginRedirect {
+  redirect: string
+}

--- a/src/types/Login.ts
+++ b/src/types/Login.ts
@@ -7,3 +7,23 @@ export interface LoginProvider {
 export interface LoginRedirect {
   redirect: string
 }
+
+// Corresponds to body returned by `/auth/userinfo`
+export interface UserInfo {
+  displayname: string,
+  github_login: string,
+  github_avatar: string,
+  'dev-flatpaks': string[],
+}
+
+// State houses user info, along with whether it's currently mid-request
+export interface UserState {
+  loading: boolean,
+  info?: UserInfo
+}
+
+// For calls to user state reducer's dispatch method
+export interface UserStateAction {
+  type: string,
+  info?: UserInfo
+}


### PR DESCRIPTION
Adding the login flow, basic user page and login status widget. Was suggested I bundle these into a single PR at one of our weekly syncs since they're all so interlinked. Made some effort to clean up the git history, but if any is too messy just point it out and I'll fix it.

- Adds `/login` route which displays available login providers.
    - Using static-site generation (through Next.js) to get providers since they aren't expected to change live. Easy to rework this in future if needed.
    - When user clicks a provider the GET request to `/login/<provider>` is made (must be done client-side to initiate login flow with session cookie) and then the browser redirected out to the auth provider as expected.
    - Redirects to the user page if already logged in.
- Adds callback route `/login/github` which makes the follow up POST request to backend
    - On successful login user is redirected to their user page and a follow up request is made for the user data.
    - If/when more providers are later added this could be handled with dynamic routing to reuse the common behaviour.
- Adds route `/userpage` which will be the page displaying basic user details and the logout option (deletion option will come later).
    - I suggest further population of userpage be done as a follow up PR.
- Adds a react context and reducer to manage user state separate from rendering logic and without lots of "prop drilling".
    - A provider component which wraps its children in the necessary context providers is introduced to wrap components at the `_app` page level. Meaning these contexts are available for use by all components.
        - When the provider is first mounted at the start of a session (only then) a request is made for the user data meaning components  (e.g. login status) will render as appropriate if logged in during a previous session.
    - Hooks are exported to allow easy use of the user data context and the user data dispatch function (for updating the data with actions, e.g. upon login or logout).
- Adds a react component to reflect the current logged in (or logged out) user status. This is placed in the footer (as suggested on respective issue) while this is a developer only login.
    - Shows GitHub avatar alongside display name when logged in.
    - Shows a link to the login page when logged out.
- Includes some handling for edge cases and errors:
    - Introduced a FeedbackMessage component for consistent styling of error/success messages. Not in love with how this solution looks, but just wanted to get error handling in a functional state.
        - Shown on logout if network error or bad response occurs.
        - Shown during login if fetching provider redirect has network error or bad response.
        - Shown during login at the callback page (`login/github`) if the POST request encounters a network error or bad response.
    - Performs some client-side rerouting if user state is logged in and they visit the login pages. Likewise if logged out and visiting the user page.

Closes #163
Closes #191
Closes #162
Closes #164