### PR TITLE
Use blurhash from backend

### DIFF
--- a/src/components/application/Details.tsx
+++ b/src/components/application/Details.tsx
@@ -35,6 +35,7 @@ function categoryToSeoCategories(categories: string[]) {
 
   return categories.map(categoryToSeoCategory).join(' ')
 }
+
 function categoryToSeoCategory(category) {
   switch (category) {
     case 'AudioVideo':
@@ -193,6 +194,8 @@ const Details: FunctionComponent<Props> = ({ app, summary, stats, developerApps 
                       alt='Screenshot'
                       loading='eager'
                       priority={index === 0}
+                      placeholder='blur'
+                      blurDataURL={pickedScreenshot.blurhash}
                     />
                   )
                 })}

--- a/src/types/Appstream.ts
+++ b/src/types/Appstream.ts
@@ -68,21 +68,22 @@ export interface Screenshot {
   '752x423'?: string
   '1248x702'?: string
   '1504x846'?: string
+  blurhash?: string
 }
 
 export function pickScreenshot(screenshot: Screenshot) {
   if (screenshot['1504x846']) {
-    return { url: screenshot['1504x846'], width: 1504, height: 846 }
+    return { url: screenshot['1504x846'], width: 1504, height: 846, blurhash: screenshot.blurhash }
   } else if (screenshot['1248x702']) {
-    return { url: screenshot['1248x702'], width: 1248, height: 702 }
+    return { url: screenshot['1248x702'], width: 1248, height: 702, blurhash: screenshot.blurhash }
   } else if (screenshot['752x423']) {
-    return { url: screenshot['752x423'], width: 752, height: 423 }
+    return { url: screenshot['752x423'], width: 752, height: 423, blurhash: screenshot.blurhash }
   } else if (screenshot['624x351']) {
-    return { url: screenshot['624x351'], width: 624, height: 351 }
+    return { url: screenshot['624x351'], width: 624, height: 351, blurhash: screenshot.blurhash }
   } else if (screenshot['224x126']) {
-    return { url: screenshot['224x126'], width: 224, height: 126 }
+    return { url: screenshot['224x126'], width: 224, height: 126, blurhash: screenshot.blurhash }
   } else if (screenshot['112x63']) {
-    return { url: screenshot['112x63'], width: 112, height: 63 }
+    return { url: screenshot['112x63'], width: 112, height: 63, blurhash: screenshot.blurhash }
   } else {
     return undefined
   }


### PR DESCRIPTION
Frontend part of https://github.com/flathub/backend/pull/105

In general, I think we want this, especially with mobile in mid.

Why I'm not so sure:
1. It doesn't look as cool as I want it to be, the effect is kinda weird (at least when observing at 2g)
2. For some reason there are errors in the frontend console log. It seems like it tries to access the url + blurhash and fails. It also seems like it's caused by chartjs, which is even weirder. 