### PR TITLE
Show top apps instead of same content as landing page

### DIFF
--- a/pages/apps/index.tsx
+++ b/pages/apps/index.tsx
@@ -1,20 +1,17 @@
 import { GetStaticProps } from 'next'
-import { Collections } from '../../src/types/Collection'
-import fetchCollection from '../../src/fetchers'
+import { Appstream } from '../../src/types/Appstream'
+import { fetchCategory } from '../../src/fetchers'
 import Main from '../../src/components/layout/Main'
 import { APPS_IN_PREVIEW_COUNT } from '../../src/env'
 import { NextSeo } from 'next-seo'
-import ApplicationSections from '../../src/components/application/Sections'
 import Link from 'next/link'
 import Tile from '../../src/components/Tile'
 import { Category, categoryToName } from '../../src/types/Category'
 import styles from './index.module.scss'
+import ApplicationSection from '../../src/components/application/ApplicationSection'
 
 export default function Apps({
-  recentlyUpdated,
-  editorsChoiceApps,
-  editorsChoiceGames,
-  popular,
+  topAppsByCategory,
 }) {
   return (
     <Main>
@@ -37,41 +34,25 @@ export default function Apps({
             </Link>
           ))}
         </div>
-        <ApplicationSections
-          popular={popular}
-          recentlyUpdated={recentlyUpdated}
-          editorsChoiceApps={editorsChoiceApps}
-          editorsChoiceGames={editorsChoiceGames}
-        ></ApplicationSections>
+        {topAppsByCategory.map((sectionData, i) => (
+          <ApplicationSection key={`categorySection${i}`} href={`/apps/category/${encodeURIComponent(sectionData.category)}`} applications={sectionData.apps} title={categoryToName(sectionData.category)}></ApplicationSection>
+        ))}
       </div>
-    </Main>
+    </Main >
   )
 }
 
 export const getStaticProps: GetStaticProps = async () => {
-  const recentlyUpdated = await fetchCollection(
-    Collections.recentlyUpdated,
-    APPS_IN_PREVIEW_COUNT
-  )
-  const editorsChoiceApps = await fetchCollection(
-    Collections.editorsApps,
-    APPS_IN_PREVIEW_COUNT
-  )
-  const editorsChoiceGames = await fetchCollection(
-    Collections.editorsGames,
-    APPS_IN_PREVIEW_COUNT
-  )
-  const popular = await fetchCollection(
-    Collections.popular,
-    APPS_IN_PREVIEW_COUNT
-  )
+  let topAppsByCategory: { category: string, apps: Appstream[] }[] = [];
 
+  const categoryPromise = Object.keys(Category).map(async (category: Category) => {
+    return { category, apps: await (await fetchCategory(category, 1, APPS_IN_PREVIEW_COUNT)) }
+  })
+
+  topAppsByCategory = await Promise.all(categoryPromise);
   return {
     props: {
-      recentlyUpdated,
-      editorsChoiceApps,
-      editorsChoiceGames,
-      popular,
+      topAppsByCategory,
     },
   }
 }

--- a/src/env.ts
+++ b/src/env.ts
@@ -14,8 +14,14 @@ export const POPULAR_URL: string = `${BASE_URI}/popular`
 export const EDITORS_PICKS_GAMES_URL: string = `${BASE_URI}/picks/games`
 export const EDITORS_PICKS_APPS_URL: string = `${BASE_URI}/picks/apps`
 export const RECENTLY_UPDATED_URL: string = `${BASE_URI}/collection/recently-updated`
-export const CATEGORY_URL = (category: keyof typeof Category): string =>
-  `${BASE_URI}/category/${category}`
+export const CATEGORY_URL = (category: keyof typeof Category, page?: number, per_page?: number): string => {
+  if (page && per_page) {
+    return `${BASE_URI}/category/${category}?page=${page}&per_page=${per_page}`
+  }
+  else {
+    return `${BASE_URI}/category/${category}`
+  }
+}
 export const DEVELOPERS_URL = `${BASE_URI}/developer`
 export const DEVELOPER_URL = (developer: string): string =>
   `${BASE_URI}/developer/${encodeURIComponent(developer)}`

--- a/src/fetchers.ts
+++ b/src/fetchers.ts
@@ -126,8 +126,8 @@ export default async function fetchCollection(
   return items.filter((item) => Boolean(item))
 }
 
-export async function fetchCategory(category: keyof typeof Category) {
-  const appListRes = await fetch(CATEGORY_URL(category))
+export async function fetchCategory(category: keyof typeof Category, page?: number, per_page?: number): Promise<Appstream[]> {
+  const appListRes = await fetch(CATEGORY_URL(category, page, per_page))
   const appList = await appListRes.json()
 
   const items: Appstream[] = await Promise.all(appList.map(fetchAppstream))


### PR DESCRIPTION
This makes the page way more useful and actually fun to look at

We don't fetch just the first 6 apps, but filter these on the client side. It's probably causing some traffic, but shouldn't really matter, as long as we run it on the same infra.

Anyway, if we want to change that, changing the endpoints should be easy.