### PR TITLE
[WiP] Make search calling backend instead of next server

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,4 +2,7 @@ module.exports = {
   images: {
     domains: ['flathub.org', 'dl.flathub.org'],
   },
+  env: {
+    API_BASE_URI: 'https://flathub.org/api/v2',
+  },
 }

--- a/pages/apps/search/[query].tsx
+++ b/pages/apps/search/[query].tsx
@@ -1,38 +1,24 @@
-import { useMatomo } from '@datapunt/matomo-tracker-react'
-import { GetServerSideProps } from 'next'
 import { NextSeo } from 'next-seo'
-import { useEffect } from 'react'
+import { useRouter } from 'next/router'
 import Collection from '../../../src/components/application/Collection'
-import { fetchSearchQuery } from '../../../src/fetchers'
-import { Appstream } from '../../../src/types/Appstream'
+import { useSearchQuery } from '../../../src/hooks/useSearchQuery'
 
-export default function Search({ applications, query }) {
-  const { trackSiteSearch } = useMatomo()
+export default function Search() {
+  const router = useRouter()
+  const { query } = router.query
 
-  useEffect(() => {
-    trackSiteSearch({
-      keyword: query,
-      count: applications.length,
-    })
-  }, [trackSiteSearch, query, applications])
+  const searchResult = useSearchQuery(query as string)
 
   return (
     <>
       <NextSeo title={`Search for ${query}`} />
 
-      <Collection title={`Search for '${query}'`} applications={applications} />
+      {searchResult && (
+        <Collection
+          title={`Search for '${query}'`}
+          applications={searchResult}
+        />
+      )}
     </>
   )
-}
-
-export const getServerSideProps: GetServerSideProps = async (context) => {
-  const query = context.query.query as string
-  const applications: Appstream[] = await fetchSearchQuery(query)
-
-  return {
-    props: {
-      applications,
-      query,
-    },
-  }
 }

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,7 +1,6 @@
 import { Category } from './types/Category'
 
 const BASE_URI: string = process.env.API_BASE_URI
-
 export const APPSTREAM_URL: string = `${BASE_URI}/appstream`
 export const APP_DETAILS = (id: string): string => `${APPSTREAM_URL}/${id}`
 export const SUMMARY_DETAILS = (id: string): string =>
@@ -14,11 +13,14 @@ export const POPULAR_URL: string = `${BASE_URI}/popular`
 export const EDITORS_PICKS_GAMES_URL: string = `${BASE_URI}/picks/games`
 export const EDITORS_PICKS_APPS_URL: string = `${BASE_URI}/picks/apps`
 export const RECENTLY_UPDATED_URL: string = `${BASE_URI}/collection/recently-updated`
-export const CATEGORY_URL = (category: keyof typeof Category, page?: number, per_page?: number): string => {
+export const CATEGORY_URL = (
+  category: keyof typeof Category,
+  page?: number,
+  per_page?: number
+): string => {
   if (page && per_page) {
     return `${BASE_URI}/category/${category}?page=${page}&per_page=${per_page}`
-  }
-  else {
+  } else {
     return `${BASE_URI}/category/${category}`
   }
 }

--- a/src/fetchers.ts
+++ b/src/fetchers.ts
@@ -126,7 +126,11 @@ export default async function fetchCollection(
   return items.filter((item) => Boolean(item))
 }
 
-export async function fetchCategory(category: keyof typeof Category, page?: number, per_page?: number): Promise<Appstream[]> {
+export async function fetchCategory(
+  category: keyof typeof Category,
+  page?: number,
+  per_page?: number
+): Promise<Appstream[]> {
   const appListRes = await fetch(CATEGORY_URL(category, page, per_page))
   const appList = await appListRes.json()
 
@@ -164,10 +168,9 @@ export async function fetchDeveloperApps(developer: string | undefined) {
 }
 
 export async function fetchSearchQuery(query: string) {
+  console.log(SEARCH_APP(query))
   const appListRes = await fetch(SEARCH_APP(query))
-  const appList = await appListRes.json()
-
-  console.log("\nSearch for query: '", query, "' fetched")
+  const appList: Appstream[] = await appListRes.json()
 
   return appList.filter((item) => Boolean(item))
 }

--- a/src/hooks/useSearchQuery.ts
+++ b/src/hooks/useSearchQuery.ts
@@ -1,0 +1,25 @@
+import { useMatomo } from '@datapunt/matomo-tracker-react'
+import { useState, useEffect } from 'react'
+
+import { fetchSearchQuery } from '../fetchers'
+import { Appstream } from '../types/Appstream'
+
+export function useSearchQuery(query: string): Appstream[] {
+  const { trackSiteSearch } = useMatomo()
+  const [searchResult, setSearchResult] = useState<Appstream[] | null>(null)
+
+  useEffect(() => {
+    const callSearch = async () => {
+      const applications = await fetchSearchQuery(query)
+      setSearchResult(applications)
+      trackSiteSearch({
+        keyword: query as string,
+        count: applications.length,
+      })
+    }
+
+    if (query) callSearch()
+  }, [trackSiteSearch, query])
+
+  return searchResult
+}


### PR DESCRIPTION
We want to use this app as a static files, without Next.js server running on some cloud. To achieve that, we have to call backend /search endpoint directly from browser.

I make it a WiP. cause probably it requires some changes from backend as well (CORS)