### PR TITLE
Add account deletion option to user page

### DIFF
--- a/src/components/ConfirmDialog.module.scss
+++ b/src/components/ConfirmDialog.module.scss
@@ -1,38 +1,42 @@
 .dialog {
-  // Want to show dialog on top of main page, centered on screen
+  // Dialog appears over page, to right hand side of screen
   position: fixed;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
+  top: calc(var(--header-height) + 20px);
+  right: 20px;
   margin: auto;
   z-index: 20;
 
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  grid-template-rows: 2fr 1fr;
+  // Drive the dialog size by its content
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 
-  // Want dialog to occupy the screen, height should be upper bound for
-  // portrait devices and lower bound if the browser window is shrunk
-  width: 50vw;
-  height: max(200px, min(30vh, 300px));
+  padding: 10px;
 
   border: 3px solid var(--text-secondary);
   border-radius: var(--border-radius);
 
   background-color: var(--bg-color-primary);
 
-  p {
-    margin: 10px;
-    font-size: 20pt;
-    grid-row: 1;
-    grid-column-start: 1;
-    grid-column-end: 3;
+  input {
+    border: 3px solid var(--text-secondary);
+    border-radius: var(--border-radius);
+    line-height: 1.7;
+    width: 100%;
+    padding: 10px;
   }
 
-  button {
-    grid-row: 2;
-    margin: 10px;
-    align-self: end;
+  .actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px;
+    margin-top: 10px;
+
+    .confirm {
+      grid-column: 1;
+    }
+    .cancel {
+      grid-column: 2;
+    }
   }
 }

--- a/src/components/ConfirmDialog.module.scss
+++ b/src/components/ConfirmDialog.module.scss
@@ -1,0 +1,38 @@
+.dialog {
+  // Want to show dialog on top of main page, centered on screen
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  margin: auto;
+  z-index: 20;
+
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 2fr 1fr;
+
+  // Want dialog to occupy the screen, height should be upper bound for
+  // portrait devices and lower bound if the browser window is shrunk
+  width: 50vw;
+  height: max(200px, min(30vh, 300px));
+
+  border: 3px solid var(--text-secondary);
+  border-radius: var(--border-radius);
+
+  background-color: var(--bg-color-primary);
+
+  p {
+    margin: 10px;
+    font-size: 20pt;
+    grid-row: 1;
+    grid-column-start: 1;
+    grid-column-end: 3;
+  }
+
+  button {
+    grid-row: 2;
+    margin: 10px;
+    align-self: end;
+  }
+}

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -4,6 +4,7 @@ import styles from './ConfirmDialog.module.scss'
 
 interface Props {
   prompt: string,
+  entry?: string,
   action: string,
   onConfirmed: () => void,
   onCancelled: () => void
@@ -14,12 +15,14 @@ interface Props {
  */
 const ConfirmDialog: FunctionComponent<Props> = ({
   prompt,
+  entry,
   action,
   onConfirmed,
-  onCancelled
+  onCancelled,
 }) => {
   const [confirmed, setConfirmed] = useState(false)
   const [cancelled, setCancelled] = useState(false)
+  const [text, setText] = useState('')
 
   useEffect(() => {
     if (confirmed) onConfirmed()
@@ -29,10 +32,34 @@ const ConfirmDialog: FunctionComponent<Props> = ({
     if (cancelled) onCancelled()
   }, [onCancelled, cancelled])
 
+  const toEnter = <div>
+    <p>{`Enter "${entry}" to continue.`}</p>
+    <input
+      value={text}
+      onInput={e => setText((e.target as HTMLInputElement).value)}
+    />
+  </div>
+
+  const confirm = <Button
+    className={styles.confirm}
+    onClick={() => setConfirmed(true)}
+    type='primary'
+  >
+    {action}
+  </Button>
+
   return (<div className={styles.dialog}>
     <p>{prompt}</p>
-    <Button onClick={() => setConfirmed(true)} type='primary'>{action}</Button>
-    <Button onClick={() => setCancelled(true)} type='primary'>Cancel</Button>
+    {entry ? toEnter : <></>}
+    <div className={styles.actions}>
+      {(entry && text === entry) ? confirm : <></>}
+      <Button
+      className={styles.cancel}
+      onClick={() => setCancelled(true)}
+      type='primary'>
+        Cancel
+      </Button>
+    </div>
   </div>)
 }
 

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,0 +1,39 @@
+import { FunctionComponent, useEffect, useState } from 'react'
+import Button from './Button'
+import styles from './ConfirmDialog.module.scss'
+
+interface Props {
+  prompt: string,
+  action: string,
+  onConfirmed: () => void,
+  onCancelled: () => void
+}
+
+/** A dialog to confirm an action and perform a callback function on
+ * confirmation or cancellation.
+ */
+const ConfirmDialog: FunctionComponent<Props> = ({
+  prompt,
+  action,
+  onConfirmed,
+  onCancelled
+}) => {
+  const [confirmed, setConfirmed] = useState(false)
+  const [cancelled, setCancelled] = useState(false)
+
+  useEffect(() => {
+    if (confirmed) onConfirmed()
+  }, [onConfirmed, confirmed])
+
+  useEffect(() => {
+    if (cancelled) onCancelled()
+  }, [onCancelled, cancelled])
+
+  return (<div className={styles.dialog}>
+    <p>{prompt}</p>
+    <Button onClick={() => setConfirmed(true)} type='primary'>{action}</Button>
+    <Button onClick={() => setCancelled(true)} type='primary'>Cancel</Button>
+  </div>)
+}
+
+export default ConfirmDialog

--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -23,7 +23,7 @@ const Spinner: FunctionComponent<Props> = ({ size, text='Loading...' }) => {
         <path className={styles.front} d='M50,50l0,50a50,50 0 0 1 -50,-50z' />
         <circle cx='50' cy='50' r='45' className={styles.center} />
       </svg>
-      <p>{text}</p>
+      {text ? <p>{text}</p> : <></>}
     </div>
   )
 }

--- a/src/components/user/DeleteButton.tsx
+++ b/src/components/user/DeleteButton.tsx
@@ -64,6 +64,7 @@ const DeleteButton: FunctionComponent = () => {
     // Callbacks must clear the token to hide the dialog
     return <ConfirmDialog
       prompt='Delete your account?'
+      entry='I wish to delete my account'
       action='Delete Account'
       onConfirmed={() => {
         deleteAccount(dispatch, setWaiting, setError, token)

--- a/src/components/user/DeleteButton.tsx
+++ b/src/components/user/DeleteButton.tsx
@@ -1,0 +1,92 @@
+import { FunctionComponent, useEffect, useState } from 'react'
+import { deleteAccount } from '../../context/actions'
+import { useUserDispatch } from '../../context/user-info'
+import { USER_DELETION_URL } from '../../env'
+import Button from '../Button'
+import ConfirmDialog from '../ConfirmDialog'
+import FeedbackMessage from '../FeedbackMessage'
+import Spinner from '../Spinner'
+
+/**
+ * Performs a GET request to the API to initiate user deletion.
+ * @param waiting Function to set the async state of the component
+ * @param error Function for displaying errors (usually component state)
+ * @param success Callback accepting the deletion token on success
+ */
+async function requestDeletion(
+  waiting: (a: boolean) => void,
+  error: (msg: string) => void,
+  success: (token: string) => void,
+) {
+  waiting(true)
+
+  let res: Response
+  try {
+    res = await fetch(USER_DELETION_URL, { credentials: 'include' })
+  } catch {
+    error('A network error occured during deletion. Refresh and try again.')
+    return
+  } finally {
+    waiting(false)
+  }
+
+  if (res.ok) {
+    const data = await res.json()
+    if (data.status == 'ok') {
+      success(data.token)
+    } else {
+      error(data.message)
+    }
+  } else {
+    error('A network error occured during deletion. Refresh and try again.')
+  }
+}
+
+
+const DeleteButton: FunctionComponent = () => {
+  // Using state to prevent user repeatedly initating fetches
+  const [clicked, setClicked] = useState(false)
+  const [waiting, setWaiting] = useState(false)
+  const [error, setError] = useState('')
+  const [token, setToken] = useState('')
+  const dispatch = useUserDispatch()
+
+  // Only make a request on first click
+  useEffect(() => {
+    if (clicked) { requestDeletion(setWaiting, setError, setToken) }
+  }, [dispatch, clicked])
+
+  if (waiting) {
+    return <Spinner size={30} text='' />
+  }
+
+  if (token) {
+    // Callbacks must clear the token to hide the dialog
+    return <ConfirmDialog
+      prompt='Delete your account?'
+      action='Delete Account'
+      onConfirmed={() => {
+        deleteAccount(dispatch, setWaiting, setError, token)
+        setToken('')
+      }}
+      onCancelled={() => {
+        // Hide dialog and allow reuse of button
+        setToken('')
+        setClicked(false)
+      }}
+    />
+  }
+
+  // There may have been a network error
+  if (error) {
+    return <FeedbackMessage success={false} message={error} />
+  }
+
+  return (
+    <Button onClick={() => setClicked(true)} type='secondary'>
+      Delete<br/>Account
+    </Button>
+  )
+}
+
+export default DeleteButton

--- a/src/components/user/Details.module.scss
+++ b/src/components/user/Details.module.scss
@@ -28,4 +28,18 @@
       margin-bottom: 10px;
     }
   }
+
+  .actions {
+    margin-left: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    justify-content: center;
+
+    button {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+  }
 }

--- a/src/components/user/Details.tsx
+++ b/src/components/user/Details.tsx
@@ -1,6 +1,7 @@
 import { FunctionComponent } from 'react'
 import { useUserContext } from '../../context/user-info'
 import LogoutButton from '../login/LogoutButton'
+import DeleteButton from './DeleteButton'
 import styles from './Details.module.scss'
 
 const UserDetails: FunctionComponent = () => {
@@ -33,8 +34,9 @@ const UserDetails: FunctionComponent = () => {
             rel='noreferrer'
             title='Open in new tab'>@{github_login}</a></p>
         </div>
-        <div className='actions'>
+        <div className={styles.actions}>
           <LogoutButton />
+          <DeleteButton />
         </div>
       </div>
     </div >

--- a/src/env.ts
+++ b/src/env.ts
@@ -38,6 +38,7 @@ export const IMAGE_BASE_URL: string = `${process.env.NEXT_PUBLIC_SITE_BASE_URI}/
 export const LOGIN_PROVIDERS_URL: string = `${BASE_URI}/auth/login`
 export const USER_INFO_URL: string = `${BASE_URI}/auth/userinfo`
 export const LOGOUT_URL: string = `${BASE_URI}/auth/logout`
+export const USER_DELETION_URL: string = `${BASE_URI}/auth/deleteuser`
 
 export const IS_PRODUCTION: boolean =
   process.env.NEXT_PUBLIC_IS_PRODUCTION === 'true'


### PR DESCRIPTION
- Adds a generic dialog component for whenever action confirmation is needed.
- Adds a "delete account" button under the "log out" button on the user page.
- When used, a confirmation dialog appears and the final deletion request is only sent off if the user enters the text "I wish to delete my account" then clicks the confirmation button.
- Modify the spinner component to allow it to be used with no text underneath. This is useful for when a small component like the deletion button wants to indicate some async operation.

The corresponding backend work for this is in-progress. I developed and tested this PR using https://github.com/ajr0d/backend/tree/ajr0d/user-deletion-flow locally.

Some considerations I had while working on this:

- I currently have the async functions for API requests spread between components/pages and the `actions.ts` file associated with the context. This feels a bit messy and I've considered:
  - Putting them into the `fetchers.ts` file, but this would mean a mix of requests being made client-side and statically in the same file which can be confusing.
  - Putting them all into the context `actions.ts` file, but this doesn't feel right since some are just flow initiation requests unrelated to the context and only using local component state.
- We may want to introduce new global styling variables for elements associated with destructive actions (for example, red colours).
- The deletion action perhaps shouldn't reside in the usual actions space of the UI, I could move it to a new section at the bottom of the page or elsewhere if we want to keep it separate. I could then more easily make the confirmation inline instead of the current dialog that comes up (it's possible as is, but requires more layout wrangling).

Closes #166 