### PR TITLE
Add support for multiple linked accounts

### DIFF
--- a/pages/login/[service].tsx
+++ b/pages/login/[service].tsx
@@ -1,3 +1,4 @@
+import { GetStaticPaths, GetStaticProps } from 'next';
 import { NextSeo } from 'next-seo';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
@@ -6,9 +7,10 @@ import Main from '../../src/components/layout/Main';
 import Spinner from '../../src/components/Spinner';
 import { login } from '../../src/context/actions';
 import { useUserContext, useUserDispatch } from '../../src/context/user-info';
+import { fetchLoginProviders } from '../../src/fetchers';
 
 export default function AuthReturnPage() {
-  // Must access query params to POST to backend for verification with GitHub
+  // Must access query params to POST to backend for oauth verification
   const router = useRouter()
 
   // Send only one request, prevent infinite loops
@@ -25,7 +27,6 @@ export default function AuthReturnPage() {
     }
 
     // Router must be ready to access query parameters
-    // This must be a dependency to ensure only runs once
     if (!router.isReady) { return }
 
     // Redirect to home if user tries some kind of directory traversal
@@ -47,4 +48,28 @@ export default function AuthReturnPage() {
       {error ? <FeedbackMessage success={false} message={error} /> : <></>}
     </Main>
   )
+}
+
+// Don't actually need static props to render the page, but must exist
+// for use of getStaticPaths
+export const getStaticProps: GetStaticProps = async () => {
+  return {
+    props: {},
+  }
+}
+
+// Only want to have routes for login providers that exist
+export const getStaticPaths: GetStaticPaths = async () => {
+  const data = await fetchLoginProviders()
+
+  const paths = data.map(d => ({
+    params: {
+      service: d.method,
+    },
+  }))
+
+  return {
+    paths,
+    fallback: false
+  }
 }

--- a/pages/userpage.tsx
+++ b/pages/userpage.tsx
@@ -1,3 +1,4 @@
+import { GetStaticProps } from 'next'
 import { NextSeo } from 'next-seo'
 import Router from 'next/router'
 import { ReactElement, useEffect } from 'react'
@@ -6,9 +7,11 @@ import Spinner from '../src/components/Spinner'
 import UserDetails from '../src/components/user/Details'
 import UserApps from '../src/components/user/UserApps'
 import { useUserContext } from '../src/context/user-info'
+import { fetchLoginProviders } from '../src/fetchers'
+import { LoginProvider } from '../src/types/Login'
 import styles from './userpage.module.scss'
 
-export default function Userpage() {
+export default function Userpage({ providers }) {
   const user = useUserContext()
 
   // Nothing to show if not logged in, return to home
@@ -25,7 +28,7 @@ export default function Userpage() {
     // Buttons above apps so they're on screen when page loads (for action visibility)
     content =
       <div className={styles.userArea}>
-        <UserDetails />
+        <UserDetails logins={providers} />
         <UserApps />
       </div>
   }
@@ -36,4 +39,15 @@ export default function Userpage() {
       {content}
     </Main>
   )
+}
+
+// Need available login providers to show options on page
+export const getStaticProps: GetStaticProps = async () => {
+  const providers: LoginProvider[] = await fetchLoginProviders()
+
+  return {
+    props: {
+      providers,
+    }
+  }
 }

--- a/src/components/login/ProviderLink.module.scss
+++ b/src/components/login/ProviderLink.module.scss
@@ -1,0 +1,29 @@
+.provider {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
+  padding: 10px;
+
+  border-radius: var(--border-radius);
+  color: var(--text-primary) !important;
+  background-color: var(--bg-color-secondary);
+
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.03), 0 1px 3px 1px rgba(0, 0, 0, 0.07),
+  0 2px 6px 2px rgba(0, 0, 0, 0.03);
+
+  &:hover {
+    cursor: pointer;
+    filter: brightness(0.96);
+    color: var(--white-10);
+    text-decoration: none;
+  }
+
+  &:active {
+    background-color: var(--bg-color-primary);
+  }
+
+  img {
+    margin-right: 10px;
+  }
+}

--- a/src/components/login/ProviderLink.tsx
+++ b/src/components/login/ProviderLink.tsx
@@ -1,4 +1,5 @@
 import { FunctionComponent, useState, useEffect } from 'react'
+import { LOGIN_PROVIDERS_URL } from '../../env'
 import { LoginProvider, LoginRedirect } from '../../types/Login'
 import FeedbackMessage from '../FeedbackMessage'
 import styles from './Providers.module.scss'
@@ -43,7 +44,7 @@ const ProviderLink: FunctionComponent<Props> = ({
 
     if (clicked) {
       setError('')
-      redirect(provider.method)
+      redirect(`${LOGIN_PROVIDERS_URL}/${provider.method}`)
     }
   }, [clicked, provider.method])
 

--- a/src/components/login/ProviderLink.tsx
+++ b/src/components/login/ProviderLink.tsx
@@ -38,7 +38,7 @@ const ProviderLink: FunctionComponent<Props> = ({
         window.location.href = data.redirect
       } else {
         setError(`${res.status} ${res.statusText}`)
-        setClicked(true)
+        setClicked(false)
       }
     }
 

--- a/src/components/login/ProviderLink.tsx
+++ b/src/components/login/ProviderLink.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent, useState, useEffect } from 'react'
 import { LOGIN_PROVIDERS_URL } from '../../env'
 import { LoginProvider, LoginRedirect } from '../../types/Login'
 import FeedbackMessage from '../FeedbackMessage'
-import styles from './Providers.module.scss'
+import styles from './ProviderLink.module.scss'
 
 interface Props {
   provider: LoginProvider,

--- a/src/components/login/Providers.module.scss
+++ b/src/components/login/Providers.module.scss
@@ -3,34 +3,6 @@
   flex-direction: column;
   align-items: center;
 
-  .provider {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-
-    margin-top: 20px;
-    padding: 10px;
-
-    border-radius: var(--border-radius);
-    color: var(--text-primary) !important;
-    background-color: var(--bg-color-secondary);
-
-    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.03), 0 1px 3px 1px rgba(0, 0, 0, 0.07),
-    0 2px 6px 2px rgba(0, 0, 0, 0.03);
-
-    &:hover {
-      cursor: pointer;
-      filter: brightness(0.96);
-      color: var(--white-10);
-      text-decoration: none;
-    }
-
-    &:active {
-      background-color: var(--bg-color-primary);
-    }
-
-    img {
-      margin-right: 10px;
-    }
-  }
+  padding: 20px;
+  gap: 20px;
 }

--- a/src/components/login/Status.tsx
+++ b/src/components/login/Status.tsx
@@ -9,13 +9,17 @@ const LoginStatus: FunctionComponent = () => {
 
   let status: ReactElement;
   if (user.info) {
+    // User has multiple login options, find one with an avatar
+    const avatar = Object.values(user.info.auths)
+      .find(auth => auth.avatar).avatar
+
     status = <>
       <h4>Logged in as:</h4>
 
       <Link href="/userpage" passHref>
         <a className={styles.user}>
         <img
-          src={user.info.github_avatar}
+          src={avatar}
           className={styles.userAvatar}
         />
         {user.info.displayname}

--- a/src/components/user/Details.module.scss
+++ b/src/components/user/Details.module.scss
@@ -1,6 +1,7 @@
 .details {
   display: grid;
-  grid-template-columns: 140px auto 120px;
+  grid-template-columns: auto 120px;
+  grid-template-rows: auto auto;
 
   padding: 16px 8px 16px 16px;
 
@@ -11,25 +12,56 @@
   background-color: var(--bg-color-secondary);
   border-radius: var(--border-radius);
 
-  .avatar {
-    width: 140px;
-    height: 140px;
-    border-radius: 70px;
+  .displayname {
+    grid-row: 1;
+    grid-column: 1;
+
+    margin-top: 0;
+    margin-bottom: 10px;
   }
 
-  .textDetails {
-    display: flex;
-    flex-direction: column;
 
+  .subsection {
     margin: auto 16px auto 16px;
 
-    h2 {
-      margin-top: 0;
-      margin-bottom: 10px;
+    h3 {
+      font-size: 18pt;
+      margin-top: 16px;
+    }
+
+    .authList {
+      display: flex;
+      flex-direction: row;
+      gap: 10px;
+
+      .linked {
+        display: flex;
+        align-items: center;
+        background-color: var(--bg-color-primary);
+        border-radius: var(--border-radius);
+
+        color: var(--text-primary);
+
+        gap: 10px;
+        padding: 0 10px;
+
+        p b {
+          text-transform: capitalize;
+        }
+
+        .avatar {
+          width: 50px;
+          height: 50px;
+          border-radius: 25px;
+        }
+      }
     }
   }
 
   .actions {
+    grid-row-start: 1;
+    grid-row-end: 3;
+
     margin-left: auto;
     display: flex;
     flex-direction: column;

--- a/src/components/user/Details.tsx
+++ b/src/components/user/Details.tsx
@@ -12,27 +12,29 @@ const UserDetails: FunctionComponent = () => {
     return <></>
   }
 
-  const {
-    github_avatar,
-    github_login,
-    displayname,
-    "dev-flatpaks": flatpaks
-  } = user.info
+  // Accounts may or may not be present in user information
+  const linkedAccounts = Object.keys(user.info.auths).map(name => {
+    const authData = user.info.auths[name]
+
+    return (<div key={name} className={styles.linked}>
+      <img
+        src={authData.avatar}
+        className={styles.avatar}
+        alt={`${authData.login}'s avatar`}
+      />
+      <p><b>{name}</b><br/>{authData.login}</p>
+    </div>)
+  })
 
   return (
     <div className='main-container'>
       <div className={styles.details}>
-        <img
-          src={github_avatar}
-          className={styles.avatar}
-          alt={`${github_login}'s avatar`}
-        />
-        <div className={styles.textDetails}>
-          <h2>{displayname}</h2>
-          <p>GitHub Account: <a href={`https://github.com/${github_login}`}
-            target='_blank'
-            rel='noreferrer'
-            title='Open in new tab'>@{github_login}</a></p>
+        <h2 className={styles.displayname}>{user.info.displayname}</h2>
+        <div className={styles.subsection}>
+          <h3>Linked Accounts</h3>
+          <div className={styles.authList}>
+            {linkedAccounts}
+          </div>
         </div>
         <div className={styles.actions}>
           <LogoutButton />

--- a/src/components/user/Details.tsx
+++ b/src/components/user/Details.tsx
@@ -2,9 +2,15 @@ import { FunctionComponent } from 'react'
 import { useUserContext } from '../../context/user-info'
 import LogoutButton from '../login/LogoutButton'
 import DeleteButton from './DeleteButton'
+import { LoginProvider } from '../../types/Login'
 import styles from './Details.module.scss'
+import ProviderLink from '../login/ProviderLink'
 
-const UserDetails: FunctionComponent = () => {
+interface Props {
+  logins: LoginProvider[]
+}
+
+const UserDetails: FunctionComponent<Props> = ({ logins }) => {
   const user = useUserContext()
 
   // Nothing to show if not logged in
@@ -26,20 +32,39 @@ const UserDetails: FunctionComponent = () => {
     </div>)
   })
 
+  // The user may have further sign in options available
+  const linkOptions = logins
+    .filter(provider => !user.info.auths[provider.method])
+    .map(provider => <ProviderLink key={provider.method} provider={provider} />)
+
+  const loginSection = linkOptions.length
+  ?  <div className={styles.subsection}>
+      <h3>Link More Accounts</h3>
+      <div className={styles.authList}>
+        {linkOptions}
+      </div>
+    </div>
+  : <></>
+
   return (
     <div className='main-container'>
       <div className={styles.details}>
         <h2 className={styles.displayname}>{user.info.displayname}</h2>
+
         <div className={styles.subsection}>
           <h3>Linked Accounts</h3>
           <div className={styles.authList}>
             {linkedAccounts}
           </div>
         </div>
+
+        {loginSection}
+
         <div className={styles.actions}>
           <LogoutButton />
           <DeleteButton />
         </div>
+
       </div>
     </div >
   )

--- a/src/context/actions.ts
+++ b/src/context/actions.ts
@@ -11,6 +11,7 @@ import { UserStateAction } from "../types/Login";
  * @param dispatch Reducer dispatch function used to update user context
  * @param error Function for displaying errors (usually component state)
  * @param query URL query object with code and state to POST to backend
+ * as well as login provider name to determine the API endpoint
  */
 export async function login(
   dispatch: Dispatch<UserStateAction>,
@@ -21,7 +22,7 @@ export async function login(
 
   let res: Response
   try {
-    res = await fetch(`${LOGIN_PROVIDERS_URL}/github`, {
+    res = await fetch(`${LOGIN_PROVIDERS_URL}/${query.service}`, {
       method: 'POST',
       credentials: 'include', // Must use the session cookie
       headers: {

--- a/src/fetchers.ts
+++ b/src/fetchers.ts
@@ -198,11 +198,5 @@ export async function fetchLoginProviders(): Promise<LoginProvider[]> {
     return null
   }
 
-  const providers = await providersRes.json()
-
-  // Creating full URL here since env variable not available client-side
-  return providers.map((p: LoginProvider) => {
-    p.method = `${LOGIN_PROVIDERS_URL}/${p.method}`
-    return p
-  })
+  return await providersRes.json()
 }

--- a/src/types/Login.ts
+++ b/src/types/Login.ts
@@ -9,11 +9,19 @@ export interface LoginRedirect {
 }
 
 // Corresponds to body returned by `/auth/userinfo`
+export interface AuthInfo {
+  avatar?: string,
+  login?: string,
+}
+export interface UserAuths {
+  github?: AuthInfo,
+  gitlab?: AuthInfo,
+  google?: AuthInfo,
+}
 export interface UserInfo {
   displayname: string,
-  github_login: string,
-  github_avatar: string,
   'dev-flatpaks': string[],
+  auths: UserAuths,
 }
 
 // State houses user info, along with whether it's currently mid-request


### PR DESCRIPTION
- Makes the oauth callback page more generic using dynamic routing so the follow up POST request works for all login services.
- Updates the user page to handle the possibility of multiple linked accounts and missing information (i.e. rendering is no longer hardcoded to GitHub only). This involved changing the layout of the details quite a bit so that avatars are all displayed and associated to their service.
- Update the login status component to use the avatar from whichever linked account is first found.
- Integrates further account linking into the user page. Reusing the ProviderLink components from login flow since they're already fully functional. They could probably use an update to allow for different styling on this page vs on login.

How it looks:

![Screenshot from 2022-03-02 12-49-14](https://user-images.githubusercontent.com/5459452/156364743-8b01cdbf-d69c-408f-a133-1c03b508dc33.png)

Notes:

- This is made to work with Daniel's WIP backend branch: https://github.com/danielsilverstone-ct/backend/tree/add-gitlab-auth and should not be merged until the backend is. 

Closes #215