### PR TITLE
Move explore to landing page

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -10,6 +10,7 @@ import { Collections } from '../src/types/Collection'
 import ApplicationSections from '../src/components/application/Sections'
 import Button from '../src/components/Button'
 import { useTranslation } from 'next-i18next';
+import Link from 'next/link';
 
 export default function Home({
   recentlyUpdated,
@@ -38,9 +39,14 @@ export default function Home({
         >
           {t('welcome-to-flathub-index-text')}
         </p>
-        <a href='https://flatpak.org/setup/'>
-          <Button type='secondary'>{t('quick-setup')}</Button>
-        </a>
+        <div style={{ "display": "flex", "gap": "12px" }}>
+          <a href='https://flatpak.org/setup/'>
+            <Button type='secondary'>{t('quick-setup')}</Button>
+          </a>
+          <Link href='/apps' passHref>
+            <Button type='secondary'>{t('explore')}</Button>
+          </Link>
+        </div>
         <ApplicationSections
           popular={popular}
           recentlyUpdated={recentlyUpdated}
@@ -48,7 +54,7 @@ export default function Home({
           editorsChoiceGames={editorsChoiceGames}
         ></ApplicationSections>
       </div>
-    </Main>
+    </Main >
   )
 }
 

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -95,9 +95,6 @@ const Header = () => {
             id={styles.navbar}
             className={`${isMenuOpen && isMobile ? styles.responsive : ''}`}
           >
-            <Link href='/apps' passHref>
-              <a className={styles.navItem}>{t('explore')}</a>
-            </Link>
 
             <div className={styles.navItem}>
               <a


### PR DESCRIPTION
In order to have more space in the header, move the explore link to the landing page. As it's only explore by categories it shouldn't it's probably not important enough for the header.

This is a proposal, to see what people think.